### PR TITLE
update repository & service tpl content

### DIFF
--- a/tpl/create/repository.tpl
+++ b/tpl/create/repository.tpl
@@ -6,7 +6,7 @@ import (
 )
 
 type {{ .StructName }}Repository interface {
-	FirstById(ctx context.Context, id int64) (*model.{{ .StructName }}, error)
+	FirstBy(ctx context.Context, query interface{}, args ...interface{}) (*model.{{ .StructName }}, error)
 }
 
 func New{{ .StructName }}Repository(repository *Repository) {{ .StructName }}Repository {
@@ -19,8 +19,8 @@ type {{ .StructNameLowerFirst }}Repository struct {
 	*Repository
 }
 
-func (r *{{ .StructNameLowerFirst }}Repository) FirstById(ctx context.Context, id int64) (*model.{{ .StructName }}, error) {
+func (r *{{ .StructNameLowerFirst }}Repository) FirstBy(ctx context.Context, query interface{}, args ...interface{}) (*model.{{ .StructName }}, error) {
 	var {{ .StructNameLowerFirst }} model.{{ .StructName }}
-	// TODO: query db
+	// eg: db.Where(query, args...).First(&{{ .StructNameLowerFirst }}).Error
 	return &{{ .StructNameLowerFirst }}, nil
 }

--- a/tpl/create/service.tpl
+++ b/tpl/create/service.tpl
@@ -7,7 +7,7 @@ import (
 )
 
 type {{ .StructName }}Service interface {
-	Get{{ .StructName }}(ctx context.Context, id int64) (*model.{{ .StructName }}, error)
+	Get{{ .StructName }}(ctx context.Context, query interface{}, args ...interface{}) (*model.{{ .StructName }}, error)
 }
 
 func New{{ .StructName }}Service(service *Service, {{ .StructNameLowerFirst }}Repository repository.{{ .StructName }}Repository) {{ .StructName }}Service {
@@ -22,6 +22,6 @@ type {{ .StructNameLowerFirst }}Service struct {
 	{{ .StructNameLowerFirst }}Repository repository.{{ .StructName }}Repository
 }
 
-func (s *{{ .StructNameLowerFirst }}Service) Get{{ .StructName }}(ctx context.Context, id int64) (*model.{{ .StructName }}, error) {
-	return s.{{ .StructNameLowerFirst }}Repository.FirstById(ctx, id)
+func (s *{{ .StructNameLowerFirst }}Service) Get{{ .StructName }}(ctx context.Context, query interface{}, args ...interface{}) (*model.{{ .StructName }}, error) {
+	return s.{{ .StructNameLowerFirst }}Repository.FirstBy(ctx, query, args...)
 }


### PR DESCRIPTION
FirstById 只能查询一种限定条件的记录，如果有多个数据字段需要查询，需要写太多的方法。
修改成FirstBy， 参数参考 gorm 依次传参，可以灵活查询记录。
后期一个 repository 只需要实现4-5种方法即可。【增、删、改、查、分页】