### PR TITLE
docs: add Nunu Skills guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Nunu is a scaffolding tool for building Go applications. Its name comes from a g
 * [MCP Server](https://github.com/go-nunu/nunu-layout-mcp/blob/main/README.md)
 * [Monorepo Layout](https://github.com/go-nunu/nunu-layout-monorepo)
 
+## AI-assisted Development
+
+[Nunu Skills](https://github.com/go-nunu/nunu-skills) provides `build-with-nunu`, an Agent Skill that helps coding agents such as Codex and Claude Code understand Nunu project layouts and implement complete, tested features across handlers, services, repositories, routers, Wire dependency injection, jobs, tasks, and MCP servers.
+
+Install it in your project with:
+
+```bash
+npx skills add go-nunu/nunu-skills --skill build-with-nunu
+```
+
+See the [Nunu Skills repository](https://github.com/go-nunu/nunu-skills) for supported layouts, agent-specific installation options, and example prompts.
 
 ## Features
 - **Gin**: https://github.com/gin-gonic/gin

--- a/README_jp.md
+++ b/README_jp.md
@@ -18,6 +18,18 @@ Nunuは、Goアプリケーションを構築するためのスキャフォー�
 * [MCP Server](https://github.com/go-nunu/nunu-layout-mcp/blob/main/README.md)
 * [Monorepo Layout](https://github.com/go-nunu/nunu-layout-monorepo)
 
+## AI支援開発
+
+[Nunu Skills](https://github.com/go-nunu/nunu-skills) は、`build-with-nunu` というAgent Skillを提供します。CodexやClaude CodeなどのコーディングエージェントがNunuのプロジェクト構成を理解し、ハンドラー、サービス、リポジトリ、ルーター、Wireによる依存性注入、ジョブ、タスク、MCP Serverにわたる、テスト済みの完全な機能を実装できるよう支援します。
+
+プロジェクトで次のコマンドを実行してインストールできます：
+
+```bash
+npx skills add go-nunu/nunu-skills --skill build-with-nunu
+```
+
+対応するプロジェクト構成、エージェント別のインストール方法、プロンプト例については、[Nunu Skillsリポジトリ](https://github.com/go-nunu/nunu-skills)を参照してください。
+
 ## 特徴
 - **Gin**: https://github.com/gin-gonic/gin
 - **Gorm**: https://github.com/go-gorm/gorm

--- a/README_pt.md
+++ b/README_pt.md
@@ -17,6 +17,18 @@ Nunu é uma ferramenta de geração de estrutura (scaffolding) para construir ap
 * [MCP Server](https://github.com/go-nunu/nunu-layout-mcp/blob/main/README.md)
 * [Monorepo Layout](https://github.com/go-nunu/nunu-layout-monorepo)
 
+## Desenvolvimento assistido por IA
+
+O [Nunu Skills](https://github.com/go-nunu/nunu-skills) oferece o `build-with-nunu`, uma Agent Skill que ajuda agentes de programação como Codex e Claude Code a entender as estruturas de projetos Nunu e implementar funcionalidades completas e testadas envolvendo handlers, serviços, repositórios, roteadores, injeção de dependência com Wire, jobs, tarefas e servidores MCP.
+
+Instale-o em seu projeto com:
+
+```bash
+npx skills add go-nunu/nunu-skills --skill build-with-nunu
+```
+
+Consulte o [repositório Nunu Skills](https://github.com/go-nunu/nunu-skills) para conhecer as estruturas compatíveis, as opções de instalação específicas para cada agente e exemplos de prompts.
+
 
 
 ## Funcionalidades

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,6 +18,18 @@ Nunu是一个基于Golang的应用脚手架，它的名字来自于英雄联盟�
 * [MCP Server](https://github.com/go-nunu/nunu-layout-mcp/blob/main/README_zh.md)
 * [Monorepo Layout](https://github.com/go-nunu/nunu-layout-monorepo)
 
+## AI 辅助开发
+
+[Nunu Skills](https://github.com/go-nunu/nunu-skills) 提供了 `build-with-nunu` Agent Skill，可帮助 Codex、Claude Code 等编码代理理解 Nunu 项目布局，并跨处理器、服务、仓储、路由、Wire 依赖注入、作业、任务和 MCP Server 实现经过完整测试的功能。
+
+在项目中运行以下命令即可安装：
+
+```bash
+npx skills add go-nunu/nunu-skills --skill build-with-nunu
+```
+
+有关支持的项目布局、不同编码代理的安装方式和示例提示词，请访问 [Nunu Skills 仓库](https://github.com/go-nunu/nunu-skills)。
+
 ## 功能
 - **Gin**: https://github.com/gin-gonic/gin
 - **Gorm**: https://github.com/go-gorm/gorm


### PR DESCRIPTION
## What changed

- add Nunu Skills guidance to the English, Japanese, Portuguese, and Chinese READMEs
- document the `build-with-nunu` installation command and supported agent workflow

## Why

Users need a discoverable path to the official Nunu Agent Skill from every maintained README language.

## Validation

- verified the linked `go-nunu/nunu-skills` repository is public
- checked the staged Markdown diff for whitespace errors
