### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,4 +223,4 @@ Nunu is released under the MIT License. For more information, see the [LICENSE](
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=go-nunu/nunu&type=Date)](https://star-history.com/#go-nunu/nunu&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=go-nunu/nunu&type=Date)](https://star-history.dera.page/#go-nunu/nunu&Date)

--- a/README_jp.md
+++ b/README_jp.md
@@ -221,4 +221,4 @@ Nunuは、MITライセンスの下でリリースされています。詳細に�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=go-nunu/nunu&type=Date)](https://star-history.com/#go-nunu/nunu&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=go-nunu/nunu&type=Date)](https://star-history.dera.page/#go-nunu/nunu&Date)

--- a/README_pt.md
+++ b/README_pt.md
@@ -224,4 +224,4 @@ O Nunu é lançado sob a Licença MIT. Para mais informações, consulte o arqui
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=go-nunu/nunu&type=Date)](https://star-history.com/#go-nunu/nunu&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=go-nunu/nunu&type=Date)](https://star-history.dera.page/#go-nunu/nunu&Date)

--- a/README_zh.md
+++ b/README_zh.md
@@ -257,4 +257,4 @@ Nunu是根据MIT许可证发布的。有关更多信息，请参见[LICENSE](LIC
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=go-nunu/nunu&type=Date)](https://star-history.com/#go-nunu/nunu&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=go-nunu/nunu&type=Date)](https://star-history.dera.page/#go-nunu/nunu&Date)


### PR DESCRIPTION
The star history chart displayed in our README files is currently broken due to GitHub stargazer API restrictions. This change points the chart to a working alternative so the repository history renders correctly again.